### PR TITLE
Enable automatic recovery of connection

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using RabbitMQ.Client;
 using Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ;
 
@@ -68,10 +69,14 @@ namespace Serilog.Sinks.RabbitMQ
         private IConnectionFactory GetConnectionFactory()
         {
             // prepare connection factory
-            var connectionFactory = new ConnectionFactory();
-            connectionFactory.HostName = _config.Hostname;
-            connectionFactory.UserName = _config.Username;
-            connectionFactory.Password = _config.Password;
+            var connectionFactory = new ConnectionFactory
+            {
+                HostName = _config.Hostname,
+                UserName = _config.Username,
+                Password = _config.Password,
+                AutomaticRecoveryEnabled = true,
+                NetworkRecoveryInterval = TimeSpan.FromSeconds(2)
+            };
 
             // setup heartbeat if needed
             if (_config.Heartbeat > 0)


### PR DESCRIPTION
Enable the RabbitMQ client to automatically try to recover from losing connection to the broker.
Ref. https://www.rabbitmq.com/dotnet-api-guide.html#connection-recovery