### PR TITLE
Dispose `RabbitMQClient`

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.RabbitMQ
     /// <summary>
     /// RabbitMqClient - this class is the engine that lets you send messages to RabbitMq
     /// </summary>
-    public class RabbitMQClient
+    public class RabbitMQClient : IDisposable
     {
         // configuration member
         private readonly RabbitMQConfiguration _config;
@@ -99,6 +99,12 @@ namespace Serilog.Sinks.RabbitMQ
         {
             // push message to exchange
             _model.BasicPublish(_publicationAddress, _properties, System.Text.Encoding.UTF8.GetBytes(message));
+        }
+
+        public void Dispose()
+        {
+            _model.Dispose();
+            _connection.Dispose();
         }
     }
 }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -51,5 +51,11 @@ namespace Serilog.Sinks.RabbitMQ
                 _client.Publish(sw.ToString());
             }
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _client.Dispose();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #34.

If you want to see the difference please pull [this branch](https://github.com/softawaregmbh/serilog-sinks-rabbitmq/tree/dispose-sample) and run the console application (note that it requires VS2017).

The sample application starts a timer and logs a message periodically. When pressing `Enter` the logger is disposed and the application quits. No more logs are written.

Now try commenting out `RabbitMQSink.Dispose` and run the application again.
You'll see that after pressing `Enter` the loggers are still outputting messages and the application doesn't really quit.