### PR TITLE
Add support for multiple hostnames

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtension.cs
+++ b/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtension.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using RabbitMQ.Client;
 using Serilog.Configuration;
 using Serilog.Formatting;
@@ -106,6 +108,97 @@ namespace Serilog
             return
                 loggerConfiguration
                     .Sink(new RabbitMQSink(config, formatter, formatProvider));
+        }
+
+        /// <summary>
+        /// Configures Serilog logger configuration with RabbitMQ
+        /// </summary>
+        public static LoggerConfiguration RabbitMQ(
+            this LoggerSinkConfiguration loggerConfiguration,
+            IList<string> hostnames,
+            string username,
+            string password,
+            string exchange,
+            string exchangeType,
+            RabbitMQDeliveryMode deliveryMode,
+            string routeKey,
+            int port,
+            string vHost,
+            ushort heartbeat,
+            IProtocol protocol,
+            int batchPostingLimit,
+            TimeSpan period,
+            ITextFormatter formatter,
+            IFormatProvider formatProvider = null)
+        {
+            // guards
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (hostnames == null) throw new ArgumentNullException("hostnames", "hostnames cannot be 'null'. Enter valid hostnames.");
+            if (hostnames.Count == 0) throw new ArgumentException("hostnames cannot be empty, specify at least one hostname", "hostnames");
+            if (string.IsNullOrEmpty(username)) throw new ArgumentException("username cannot be 'null' or and empty string.");
+            if (password == null) throw new ArgumentException("password cannot be 'null'. Specify an empty string if password is empty.");
+            if (port <= 0 || port > 65535) throw new ArgumentOutOfRangeException("port", "port must be in a valid range (1 and 65535)");
+
+            // setup configuration
+            var config = new RabbitMQConfiguration
+            {
+                Hostnames = hostnames,
+                Username = username,
+                Password = password,
+                Exchange = exchange ?? string.Empty,
+                ExchangeType = exchangeType ?? string.Empty,
+                DeliveryMode = deliveryMode,
+                RouteKey = routeKey ?? string.Empty,
+                Port = port,
+                VHost = vHost ?? string.Empty,
+                Protocol = protocol ?? Protocols.DefaultProtocol,
+                Heartbeat = heartbeat,
+                BatchPostingLimit = batchPostingLimit == default(int) ? DefaultBatchPostingLimit : batchPostingLimit,
+                Period = period == default(TimeSpan) ? DefaultPeriod : period
+            };
+
+            return
+                loggerConfiguration
+                    .Sink(new RabbitMQSink(config, formatter, formatProvider));
+        }
+
+        /// <summary>
+        /// Configures Serilog logger configuration with RabbitMQ
+        /// </summary>
+        public static LoggerConfiguration RabbitMQ(
+            this LoggerSinkConfiguration loggerConfiguration,
+            IEnumerable<string> hostnames,
+            string username,
+            string password,
+            string exchange,
+            string exchangeType,
+            RabbitMQDeliveryMode deliveryMode,
+            string routeKey,
+            int port,
+            string vHost,
+            ushort heartbeat,
+            IProtocol protocol,
+            int batchPostingLimit,
+            TimeSpan period,
+            ITextFormatter formatter,
+            IFormatProvider formatProvider = null)
+        {
+            return loggerConfiguration.RabbitMQ(
+                hostnames.ToList(),
+                username,
+                password,
+                exchange,
+                exchangeType,
+                deliveryMode,
+                routeKey,
+                port,
+                vHost,
+                heartbeat,
+                protocol,
+                batchPostingLimit,
+                period,
+                formatter,
+                formatProvider);
         }
 
         private const int DefaultBatchPostingLimit = 50;

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -55,7 +55,12 @@ namespace Serilog.Sinks.RabbitMQ
         {
             // prepare endpoint
             _connectionFactory = GetConnectionFactory();
-            _connection = _connectionFactory.CreateConnection();
+
+            if (_config.Hostnames == null || _config.Hostnames.Count == 0)
+                _connection = _connectionFactory.CreateConnection();
+            else
+                _connection = _connectionFactory.CreateConnection(_config.Hostnames);
+
             _model = _connection.CreateModel();
 
             _properties = _model.CreateBasicProperties();

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using RabbitMQ.Client;
 
 namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
@@ -23,6 +24,7 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
     public class RabbitMQConfiguration
     {
         public string Hostname = string.Empty;
+        public IList<string> Hostnames = null;
         public string Username = string.Empty;
         public string Password = string.Empty;
         public string Exchange = string.Empty;


### PR DESCRIPTION
The sink could previously only take a single hostname to connect to,
this change adds a new field on the property taking multiple hostnames.
If set, this list of hostnames will be used instead of the singular one,
passing it to the RabbitMQ `ConnectionFactory`'s `CreateConnection` method
and allowing multiple hostnames to be used.

The `IConnectionFactory` interface for some reason does not contain the
version of `CreateConnection` methods that take a list of `AmqTcpEndpoint`
instances, which means the port cannot be customised on a per-host
basis. Changing [`RabbitMQClient.GetConnectionFactory`](https://github.com/sonicjolt/serilog-sinks-rabbitmq/blob/0a339488c6ffdcb4869afd9802bde96147229270/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs#L69) to return a
`ConnectionFactory` rather than `IConnectionFactory` (and then also the
`_connectionFactory` field) should remedy that.

Regarding the last part, should the `RabbitMQClient` be changed to use `ConnectionFactory` internally to allow customizing the ports? If so it would probably be best to do that in this same PR to avoid having too many different ways to pass in multiple hostnames.

This fixes #43.