### PR TITLE
Added an option to auto create exchange when using the RabbitMQSink

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtension.cs
+++ b/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtension.cs
@@ -33,7 +33,8 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             RabbitMQConfiguration rabbitMqConfiguration,
             ITextFormatter formatter,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool autoCreateExchange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (rabbitMqConfiguration == null) throw new ArgumentNullException("rabbitMqConfiguration");
@@ -76,7 +77,8 @@ namespace Serilog
             int batchPostingLimit = 0,
             TimeSpan period = default(TimeSpan),
             ITextFormatter formatter = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool autoCreateExchange = false)
         {
             // guards
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
@@ -105,7 +107,7 @@ namespace Serilog
             
             return
                 loggerConfiguration
-                    .Sink(new RabbitMQSink(config, formatter, formatProvider));
+                    .Sink(new RabbitMQSink(config, formatter, formatProvider, autoCreateExchange));
         }
 
         private const int DefaultBatchPostingLimit = 50;

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -37,7 +37,7 @@ namespace Serilog.Sinks.RabbitMQ
         /// Constructor for RabbitMqClient
         /// </summary>
         /// <param name="configuration">mandatory</param>
-        public RabbitMQClient(RabbitMQConfiguration configuration)
+        public RabbitMQClient(RabbitMQConfiguration configuration, bool autoCreateExchange)
         {
             // load configuration
             _config = configuration;
@@ -45,6 +45,10 @@ namespace Serilog.Sinks.RabbitMQ
 
             // initialize 
             InitializeEndpoint();
+            if (autoCreateExchange)
+            {
+                _model.ExchangeDeclare(_config.Exchange, _config.ExchangeType, _config.DeliveryMode == RabbitMQDeliveryMode.Durable);
+            }
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -35,11 +35,12 @@ namespace Serilog.Sinks.RabbitMQ
 
         public RabbitMQSink(RabbitMQConfiguration configuration,
             ITextFormatter formatter,
-            IFormatProvider formatProvider) : base(configuration.BatchPostingLimit, configuration.Period)
+            IFormatProvider formatProvider,
+            bool autoCreateExchange) : base(configuration.BatchPostingLimit, configuration.Period)
         {
             _formatter = formatter ?? new RawFormatter();
             _formatProvider = formatProvider;
-            _client = new RabbitMQClient(configuration);
+            _client = new RabbitMQClient(configuration, autoCreateExchange);
         }
 
         protected override void EmitBatch(IEnumerable<LogEvent> events)


### PR DESCRIPTION
When using a logger in multiple services, you don't want to declare the RabbitMQ-logger-exhange by yourself every time. Especially when RabbitMQ isn't used outside of the logger, or when the RabbitMQ-logger-exhange is the same on each service.
