### PR TITLE
Added level template in routing key

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -25,7 +25,6 @@ namespace Serilog.Sinks.RabbitMQ
     {
         // configuration member
         private readonly RabbitMQConfiguration _config;
-        private readonly PublicationAddress _publicationAddress;
 
         // endpoint members
         private IConnectionFactory _connectionFactory;
@@ -41,7 +40,6 @@ namespace Serilog.Sinks.RabbitMQ
         {
             // load configuration
             _config = configuration;
-            _publicationAddress = new PublicationAddress(_config.ExchangeType, _config.Exchange, _config.RouteKey);
 
             // initialize 
             InitializeEndpoint();
@@ -94,11 +92,16 @@ namespace Serilog.Sinks.RabbitMQ
         /// <summary>
         /// Publishes a message to RabbitMq Exchange
         /// </summary>
+        /// <param name="level"></param>
         /// <param name="message"></param>
-        public void Publish(string message)
+        public void Publish(Events.LogEventLevel level, string message)
         {
+            //Configure routing key with the log level
+            var routeKey = _config.RouteKey.Replace("{level}", level.ToString());
+            var publicationAddress = new PublicationAddress(_config.ExchangeType, _config.Exchange, routeKey);
+            
             // push message to exchange
-            _model.BasicPublish(_publicationAddress, _properties, System.Text.Encoding.UTF8.GetBytes(message));
+            _model.BasicPublish(publicationAddress, _properties, System.Text.Encoding.UTF8.GetBytes(message));
         }
 
         public void Dispose()

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.IO;
-using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Raw;
@@ -48,7 +47,7 @@ namespace Serilog.Sinks.RabbitMQ
             {
                 var sw = new StringWriter();
                 _formatter.Format(logEvent, sw);
-                _client.Publish(sw.ToString());
+                _client.Publish(logEvent.Level, sw.ToString());
             }
         }
 


### PR DESCRIPTION
This PR adds support for using the log level in the route key. When using route key `Logging.Log.Entry.{level}.Add` for example, the route key for logging a message with level `LogEventLevel.Information` will be `Logging.Log.Entry.Information.Add`.