### PR TITLE
Fix error at bootstrapping and incorrect RabbitMQ usage

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using RabbitMQ.Client;
 using Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ;
 
@@ -23,15 +25,21 @@ namespace Serilog.Sinks.RabbitMQ
     /// </summary>
     public class RabbitMQClient : IDisposable
     {
+        // synchronization locks
+        private const int MaxChannelCount = 64;
+        private readonly object _connectionLock = new object();
+        private readonly object[] _modelLocks = new object[MaxChannelCount];
+        private int _currentModelIndex = -1;
+
         // configuration member
         private readonly RabbitMQConfiguration _config;
         private readonly PublicationAddress _publicationAddress;
 
         // endpoint members
-        private IConnectionFactory _connectionFactory;
-        private IConnection _connection;
-        private IModel _model;
-        private IBasicProperties _properties;
+        private readonly IConnectionFactory _connectionFactory;
+        private readonly IModel[] _models = new IModel[MaxChannelCount];
+        private readonly IBasicProperties[] _properties = new IBasicProperties[MaxChannelCount];
+        private volatile IConnection _connection;
 
         /// <summary>
         /// Constructor for RabbitMqClient
@@ -39,27 +47,20 @@ namespace Serilog.Sinks.RabbitMQ
         /// <param name="configuration">mandatory</param>
         public RabbitMQClient(RabbitMQConfiguration configuration)
         {
+            // RabbitMQ channels are not thread-safe.
+            // https://www.rabbitmq.com/dotnet-api-guide.html#model-sharing
+            // Create a pool of channels and give each call to Publish one channel.
+            for (var i = 0; i < MaxChannelCount; i++)
+            {
+                _modelLocks[i] = new object();
+            }
+
             // load configuration
             _config = configuration;
             _publicationAddress = new PublicationAddress(_config.ExchangeType, _config.Exchange, _config.RouteKey);
 
             // initialize 
-            InitializeEndpoint();
-        }
-
-        /// <summary>
-        /// Private method, that must be run for the client to work.
-        /// <remarks>See constructor</remarks>
-        /// </summary>
-        private void InitializeEndpoint()
-        {
-            // prepare endpoint
             _connectionFactory = GetConnectionFactory();
-            _connection = _connectionFactory.CreateConnection();
-            _model = _connection.CreateModel();
-
-            _properties = _model.CreateBasicProperties();
-            _properties.DeliveryMode = (byte)_config.DeliveryMode; //persistance
         }
 
         /// <summary>
@@ -97,14 +98,91 @@ namespace Serilog.Sinks.RabbitMQ
         /// <param name="message"></param>
         public void Publish(string message)
         {
-            // push message to exchange
-            _model.BasicPublish(_publicationAddress, _properties, System.Text.Encoding.UTF8.GetBytes(message));
+            var currentModelIndex = Interlocked.Increment(ref _currentModelIndex);
+
+            // Interlocked.Increment can overflow and return a negative currentModelIndex.
+            // Ensure that currentModelIndex is always in the range of [0, MaxChannelCount) by using this formula.
+            // https://stackoverflow.com/a/14997413/263003
+            currentModelIndex = (currentModelIndex % MaxChannelCount + MaxChannelCount) % MaxChannelCount;
+            lock (_modelLocks[currentModelIndex])
+            {
+                var model = _models[currentModelIndex];
+                var properties = _properties[currentModelIndex];
+                if (model == null)
+                {
+                    var connection = GetConnection();
+                    model = connection.CreateModel();
+                    _models[currentModelIndex] = model;
+
+                    properties = model.CreateBasicProperties();
+                    properties.DeliveryMode = (byte)_config.DeliveryMode; // persistence
+                    _properties[currentModelIndex] = properties;
+                }
+
+                // push message to exchange
+                model.BasicPublish(_publicationAddress, properties, System.Text.Encoding.UTF8.GetBytes(message));
+            }
+        }
+
+        public void Close()
+        {
+            // Disposing channel and connection objects is not enough, they must be explicitly closed with the API methods.
+            // https://www.rabbitmq.com/dotnet-api-guide.html#disconnecting
+            IList<Exception> exceptions = new List<Exception>();
+            foreach (var model in _models)
+            {
+                if (model != null)
+                {
+                    try
+                    {
+                        model.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            }
+
+            try
+            {
+                _connection?.Close();
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException(exceptions);
+            }
         }
 
         public void Dispose()
         {
-            _model.Dispose();
-            _connection.Dispose();
+            foreach (var model in _models)
+            {
+                model?.Dispose();
+            }
+
+            _connection?.Dispose();
+        }
+
+        private IConnection GetConnection()
+        {
+            if (_connection == null)
+            {
+                lock (_connectionLock)
+                {
+                    if (_connection == null)
+                    {
+                        _connection = _connectionFactory.CreateConnection();
+                    }
+                }
+            }
+
+            return _connection;
         }
     }
 }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
@@ -22,18 +22,30 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
     /// </summary>
     public class RabbitMQConfiguration
     {
-        public string Hostname = string.Empty;
-        public string Username = string.Empty;
-        public string Password = string.Empty;
-        public string Exchange = string.Empty;
-        public string ExchangeType = string.Empty;
-        public RabbitMQDeliveryMode DeliveryMode = RabbitMQDeliveryMode.NonDurable;
-        public string RouteKey = string.Empty;
-        public int Port;
-        public string VHost = string.Empty;
-        public IProtocol Protocol;
-        public ushort Heartbeat;
-        public int BatchPostingLimit;
-        public TimeSpan Period;
+        public string Hostname { get; set; } = string.Empty;
+
+        public string Username { get; set; } = string.Empty;
+
+        public string Password { get; set; } = string.Empty;
+
+        public string Exchange { get; set; } = string.Empty;
+
+        public string ExchangeType { get; set; } = string.Empty;
+
+        public RabbitMQDeliveryMode DeliveryMode { get; set; } = RabbitMQDeliveryMode.NonDurable;
+
+        public string RouteKey { get; set; } = string.Empty;
+
+        public int Port { get; set; }
+
+        public string VHost { get; set; } = string.Empty;
+
+        public IProtocol Protocol { get; set; }
+
+        public ushort Heartbeat { get; set; }
+
+        public int BatchPostingLimit { get; set; }
+
+        public TimeSpan Period { get; set; }
     }
 }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.IO;
-using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Raw;
@@ -55,6 +54,18 @@ namespace Serilog.Sinks.RabbitMQ
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
+
+            try
+            {
+                // Disposing channel and connection objects is not enough, they must be explicitly closed with the API methods.
+                // https://www.rabbitmq.com/dotnet-api-guide.html#disconnecting
+                _client.Close();
+            }
+            catch
+            {
+                // ignore exceptions
+            }
+
             _client.Dispose();
         }
     }


### PR DESCRIPTION
Initialize RabbitMQ connection only on the first call to RabbitMQClient.Publish. This follows the same pattern used in [Microsoft.Extensions.Caching.Redis](https://github.com/aspnet/Extensions/blob/master/src/Caching/StackExchangeRedis/src/RedisCache.cs). Fixes #55.

Fix missing lock around IModel.BasicPublish, missing IModel.Close and missing IConnection.Close, which are documented usage requirements in [dotnet-api-guide](https://www.rabbitmq.com/dotnet-api-guide.html).

Change RabbitMQConfiguration to use properties, so that callers can [initialize the configuration](https://stackoverflow.com/a/51914622/263003) via IConfiguration.GetSection("rabbitmq").Bind(options).