### PR TITLE
Read only collection property for RabbitMQConfiguration.Hostnames

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtension.cs
+++ b/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtension.cs
@@ -145,7 +145,6 @@ namespace Serilog
             // setup configuration
             var config = new RabbitMQConfiguration
             {
-                Hostnames = hostnames,
                 Username = username,
                 Password = password,
                 Exchange = exchange ?? string.Empty,
@@ -159,6 +158,10 @@ namespace Serilog
                 BatchPostingLimit = batchPostingLimit == default(int) ? DefaultBatchPostingLimit : batchPostingLimit,
                 Period = period == default(TimeSpan) ? DefaultPeriod : period
             };
+            foreach (string hostname in hostnames)
+            {
+                config.Hostnames.Add(hostname);
+            }
 
             return
                 loggerConfiguration

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.RabbitMQ
             // prepare endpoint
             _connectionFactory = GetConnectionFactory();
 
-            if (_config.Hostnames == null || _config.Hostnames.Count == 0)
+            if (_config.Hostnames.Count == 0)
                 _connection = _connectionFactory.CreateConnection();
             else
                 _connection = _connectionFactory.CreateConnection(_config.Hostnames);

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
@@ -23,7 +23,7 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
     public class RabbitMQConfiguration
     {
         public string Hostname { get; set; } = string.Empty;
-        public IList<string> Hostnames = null;
+        public IList<string> Hostnames { get; } = new List<string>();
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public string Exchange { get; set; } = string.Empty;


### PR DESCRIPTION
as recommended by FxCop CA2227 rule: Collection properties should be read only.