### PR TITLE
remove redundant Hostname property

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConfiguration.cs
@@ -22,7 +22,6 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
     /// </summary>
     public class RabbitMQConfiguration
     {
-        public string Hostname { get; set; } = string.Empty;
         public IList<string> Hostnames { get; } = new List<string>();
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;


### PR DESCRIPTION
Removed Hostname property as it became redundant after the Hostnames collection implementation